### PR TITLE
Do not set party on debit lines of move #7627

### DIFF
--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -116,11 +116,6 @@ class TestTransaction(unittest.TestCase):
         if not accounts:
             return None
         account, = accounts
-
-        # Party required must be set to True for assigning party to
-        # account move lines as per 3.4 version changes
-        account.party_required = True
-        account.save()
         return account
 
     def setup_defaults(self):

--- a/transaction.py
+++ b/transaction.py
@@ -555,7 +555,6 @@ class PaymentTransaction(Workflow, ModelSQL, ModelView):
         }, {
             'description': self.rec_name,
             'account': journal.debit_account.id,
-            'party': self.party.id,
             'debit': amount,
             'credit': Decimal('0.0'),
             'amount_second_currency': amount_second_currency,


### PR DESCRIPTION
We need to do this as the debit account on gateway's journal
must not have party required.